### PR TITLE
Revert regex pattern in to get own username

### DIFF
--- a/phovea_security_store_ldap/ldap.py
+++ b/phovea_security_store_ldap/ldap.py
@@ -251,7 +251,7 @@ class LDAPStore(object):
       if self._config.get('use_who_am_i'):
         # Luckily there's an LDAP standard operation to help us out
         my_username = connection.extend.standard.who_am_i()
-        my_username = re.sub(r'^u:\w+\\\\', '', my_username)
+        my_username = re.sub('^u:\w+\\\\', '', my_username)
         log.debug('re.sub: %r', my_username)
       else:
         my_username = username


### PR DESCRIPTION
### Summary 

The `r` in the regular expression pattern `r'^u:\w+\\\\'` indicates a raw string in Python. According to the documentation (see https://docs.python.org/2/reference/lexical_analysis.html#string-literals) the "String literals may optionally be prefixed with a letter 'r' or 'R'; such strings are called raw strings and use different rules for interpreting backslash escape sequences." In this case the backslashes are treated as separate characters and result in a wrong regular expression pattern. Removing the `r` converts it into a regular expression.

An example can be found at https://repl.it/repls/CleverExaltedClimate