### PR TITLE
Use config settings to `bind_user` in `_get_user_groups`

### DIFF
--- a/phovea_security_store_ldap/ldap.py
+++ b/phovea_security_store_ldap/ldap.py
@@ -410,7 +410,7 @@ class LDAPStore(object):
 
     connection = _connection
     if not connection:
-      connection = self._make_connection(bind_user=dn,
+      connection = self._make_connection(bind_user=self._config.get('bind_user_dn'),
                                          bind_password=self._config.get('bind_user_password'))
       connection.bind()
 


### PR DESCRIPTION
during open the connection, the bind_user in the config should be used (instead of 'dn')